### PR TITLE
use `python3` explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ type-check:
 	mypy .
 
 test:
-	python tests/test_integration.py
+	python3 tests/test_integration.py
 
 check: lint type-check
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pip install -r requirements-dev.txt
 The project includes a demonstration of the complete nested signing protocol:
 
 ```bash
-python src/nested_signing.py
+python3 src/nested_signing.py
 ```
 
 This will:
@@ -90,7 +90,7 @@ make test
 
 Or manually:
 ```bash
-python tests/test_integration.py
+python3 tests/test_integration.py
 ```
 
 ### Code Quality


### PR DESCRIPTION
`python` might not link to Python 3 on all operating systems (e.g. it doesn't on Ubuntu 25.04), so use `python3` explicitly.